### PR TITLE
Build options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,18 @@
-build: ensure-dir build-linux build-windows build-darwin compress
+default: clean bindir
+	go build -o bin/scrape *.go
 
-ensure-dir: clean
+amd64: clean bindir linux windows darwin compress
+
+bindir:
 	mkdir bin
 
-build-linux:
+linux:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bin/scrape.linux-amd64 *.go
 
-build-windows:
+windows:
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o bin/scrape.windows-amd64.exe *.go
 
-build-darwin:
+darwin:
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o bin/scrape.darwin-amd-64 *.go
 
 compress:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 build: ensure-dir build-linux build-windows build-darwin compress
 
-ensure-dir:
-	rm -rf bin
+ensure-dir: clean
 	mkdir bin
 
 build-linux:
@@ -15,6 +14,9 @@ build-darwin:
 
 compress:
 	cd ./bin && find . -name 'scrape*' | xargs -I{} tar czf {}.tar.gz {}
+
+clean:
+	rm -rf bin
 
 snap-clean:
 	rm -f scrape_*_amd64.snap*


### PR DESCRIPTION
It seems like the default make target should build for the current system architecture, and alternative targets can be provided for cross-compiling for multiple architectures.