### PR TITLE
Removed deprecated stuff from HomeBrew bottle

### DIFF
--- a/Formula/scrape.rb
+++ b/Formula/scrape.rb
@@ -6,7 +6,6 @@ class Scrape < Formula
   desc "CLI utility to scrape emails from websites"
   homepage "https://github.com/lawzava/scrape"
   version "1.7.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
There is an error in the homebrew `brew update && brew upgrade` command:

```bash
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the lawzava/scrape tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/lawzava/homebrew-scrape/Formula/scrape.rb:9
```